### PR TITLE
Fix TypeError: Vue is not a constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
     <footer>
 
     </footer>
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
     <script src="/scripts/rison.js"></script>
     <script src="/scripts/app.js"></script>
     <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
This pull-request fixes `TypeError: Vue is not a constructor`.

## Issue
Rison Playground is not working.
* In JavaScript console, `Uncaught TypeError: Vue is not a constructor`.
* Mustache tags like `{{ rison_string }}` are displayed without replacement. #2
* Buttons don't work.

## Cause
* Rison Playground expects Vue2 but CDN returns Vue3.

## Change
* Specify Vue version in CDN URL.

## Alternative Change: Use Vue3
https://github.com/othree/rison.dev/compare/master...deton:rison.dev:vue3?expand=1
